### PR TITLE
fix(Form.php): PHP7.3 warning

### DIFF
--- a/library/Zend/Form.php
+++ b/library/Zend/Form.php
@@ -1170,7 +1170,7 @@ class Zend_Form implements Iterator, Countable, Zend_Validate_Interface
                 } else {
                     switch ($argc) {
                         case 0:
-                            continue;
+                            break;
                         case (1 <= $argc):
                             $type = array_shift($spec);
                         case (2 <= $argc):

--- a/library/Zend/Form.php
+++ b/library/Zend/Form.php
@@ -1687,7 +1687,7 @@ class Zend_Form implements Iterator, Countable, Zend_Validate_Interface
                 $order = null;
                 switch ($argc) {
                     case 0:
-                        continue;
+                        break;
                     case (1 <= $argc):
                         $subForm = array_shift($spec);
 


### PR DESCRIPTION
Fixes the `PHP 7.3: "continue" targeting switch is equivalent to "break". Did you mean to use "continue 2"?` error
